### PR TITLE
ROS2 fix map server

### DIFF
--- a/config/nav2_laserscan_params.yaml
+++ b/config/nav2_laserscan_params.yaml
@@ -383,6 +383,7 @@ map_server:
   ros__parameters:
     use_sim_time: false
     yaml_filename: map.yaml
+    frame_id: <robot_namespace>/map
 
 ### SLAM ###
 

--- a/config/nav2_pointcloud_params.yaml
+++ b/config/nav2_pointcloud_params.yaml
@@ -387,6 +387,7 @@ map_server:
   ros__parameters:
     use_sim_time: false
     yaml_filename: map.yaml
+    frame_id: <robot_namespace>/map
 
 ### SLAM ###
 


### PR DESCRIPTION
I had an issue during localization because `map_server` loaded map without namespaced fram_id.

```bash
[component_container_isolated-1] [INFO] [1731079245.291897312] [panther.amcl]: Received a 243 X 243 map @ 0.100 m/pix
[component_container_isolated-1] [WARN] [1731079245.291960240] [panther.amcl]: Frame_id of map received:'map' doesn't match global_frame_id:'panther/map'. This could cause issues with reading published topics
```

It caused that the map didn't appear.