### PR TITLE
Localcost map fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Setup environment:
 
 ```bash
 cd panther-navigation
-export OBSERVATION_TOPIC={point_cloud_topic} # change topic name to match your LIDAR pointcloud2 topic
+export OBSERVATION_TOPIC={point_cloud_topic} # absolute topic name, change topic name to match your LIDAR PointCloud2 or LaserScan topic
 export OBSERVATION_TOPIC_TYPE={msg_type} # Specify: `laserscan`, `pointcloud`
 export SLAM=True # if you have map you can run navigation without SLAM
 ```
@@ -62,7 +62,7 @@ Setup environment:
 
 ```bash
 xhost +local:docker
-export OBSERVATION_TOPIC=velodyne_points # simulation is created with velodyne LIDAR
+export OBSERVATION_TOPIC=/panther/velodyne_points # absolute topic name, simulation is created with velodyne LIDAR
 export OBSERVATION_TOPIC_TYPE=pointcloud # Specify: `laserscan`, `pointcloud`
 export SLAM=True # if you have map you can run navigation without SLAM
 ```


### PR DESCRIPTION
Giving  `export OBSERVATION_TOPIC=scan` without namespace depends on the namespace of a node.
`slam_toolbox` and `amcl` have only one prefix `/panther` what mean that the slam and localization work properly but `localcost_map` has 2 `/panther/local_costmap` and a controller has no obstacles on the local costmap. 

```bash
$ ros2 node info /panther/local_costmap/local_costmap 
/panther/local_costmap/local_costmap
  Subscribers:
    /panther/local_costmap/footprint: geometry_msgs/msg/Polygon
    /panther/local_costmap/scan: sensor_msgs/msg/LaserScan
    /parameter_events: rcl_interfaces/msg/ParameterEvent
```


I propose a fix to set absolute topic name of `OBSERVATION_TOPIC`. Updated the README.