### PR TITLE
Order in cost maps does matter, the inflation layer should at the end

### DIFF
--- a/husarion_ugv_navigation/config/nav2_params.yaml
+++ b/husarion_ugv_navigation/config/nav2_params.yaml
@@ -157,7 +157,7 @@ local_costmap:
 
       footprint: '[[0.45, 0.47], [0.45, -0.47], [-0.45, -0.47], [-0.45, 0.47]]'
 
-      plugins: [inflation_layer, obstacle_layer, voxel_layer]
+      plugins: [obstacle_layer, voxel_layer, inflation_layer]
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         cost_scaling_factor: 1.3
@@ -218,7 +218,7 @@ global_costmap:
 
       footprint: '[[0.45, 0.47], [0.45, -0.47], [-0.45, -0.47], [-0.45, 0.47]]'
 
-      plugins: [inflation_layer, obstacle_layer, static_layer, voxel_layer]
+      plugins: [static_layer, obstacle_layer, voxel_layer, inflation_layer]
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         cost_scaling_factor: 1.5


### PR DESCRIPTION
Fixed with: https://robotics.stackexchange.com/questions/104536/inflation-layer-doesnt-seem-to-be-working-in-local-costmap-specifically
Before:
![image](https://github.com/user-attachments/assets/ad06e82f-ecc7-4363-b0ef-94645c8f6d7b)


After change:
![image](https://github.com/user-attachments/assets/d10ceb92-5db4-46df-a769-0ca549c33b7f)
