### PR TITLE
Added DockDatabaseUpdaterNode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
       - id: ament_copyright
         name: ament_copyright
         description: Check if copyright notice is available in all files.
-        stages: [commit]
+        stages: [pre-commit]
         entry: ament_copyright
         language: system
 

--- a/husarion_ugv_docking/CMakeLists.txt
+++ b/husarion_ugv_docking/CMakeLists.txt
@@ -132,6 +132,17 @@ if(BUILD_TESTING)
            $<INSTALL_INTERFACE:include>)
   ament_target_dependencies(${PROJECT_NAME}_test_tf2_utils
                             ${PACKAGE_DEPENDENCIES})
+
+  ament_add_gtest(
+    ${PROJECT_NAME}_test_dock_database_updater
+    src/dock_database_updater_node.cpp test/unit/test_dock_database_updater.cpp)
+  target_link_libraries(${PROJECT_NAME}_test_dock_database_updater yaml-cpp)
+  target_include_directories(
+    ${PROJECT_NAME}_test_dock_database_updater
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+           $<INSTALL_INTERFACE:include>)
+  ament_target_dependencies(${PROJECT_NAME}_test_dock_database_updater
+                            ${PACKAGE_DEPENDENCIES})
 endif()
 
 ament_export_include_directories(include)

--- a/husarion_ugv_docking/CMakeLists.txt
+++ b/husarion_ugv_docking/CMakeLists.txt
@@ -22,9 +22,11 @@ set(PACKAGE_DEPENDENCIES
     rclcpp_lifecycle
     sensor_msgs
     std_srvs
+    tf2
     tf2_geometry_msgs
     tf2_ros
-    wibotic_msgs)
+    wibotic_msgs
+    yaml-cpp)
 
 foreach(PACKAGE IN ITEMS ${PACKAGE_DEPENDENCIES})
   find_package(${PACKAGE} REQUIRED)
@@ -73,6 +75,12 @@ ament_target_dependencies(dock_pose_publisher ${PACKAGE_DEPENDENCIES})
 
 install(TARGETS dock_pose_publisher docking_manager_node
         DESTINATION lib/${PROJECT_NAME})
+
+add_executable(dock_database_updater src/dock_database_updater_main.cpp
+                                   src/dock_database_updater_node.cpp)
+ament_target_dependencies(dock_database_updater ${PACKAGE_DEPENDENCIES})
+target_link_libraries(dock_database_updater yaml-cpp)
+install(TARGETS dock_database_updater DESTINATION lib/${PROJECT_NAME})
 
 add_library(dock_robot_bt_node SHARED src/plugins/action/dock_robot_node.cpp)
 list(APPEND plugin_libs dock_robot_bt_node)

--- a/husarion_ugv_docking/CMakeLists.txt
+++ b/husarion_ugv_docking/CMakeLists.txt
@@ -77,7 +77,7 @@ install(TARGETS dock_pose_publisher docking_manager_node
         DESTINATION lib/${PROJECT_NAME})
 
 add_executable(dock_database_updater src/dock_database_updater_main.cpp
-                                   src/dock_database_updater_node.cpp)
+                                     src/dock_database_updater_node.cpp)
 ament_target_dependencies(dock_database_updater ${PACKAGE_DEPENDENCIES})
 target_link_libraries(dock_database_updater yaml-cpp)
 install(TARGETS dock_database_updater DESTINATION lib/${PROJECT_NAME})

--- a/husarion_ugv_docking/CMakeLists.txt
+++ b/husarion_ugv_docking/CMakeLists.txt
@@ -146,14 +146,14 @@ if(BUILD_TESTING)
 
   ament_add_gtest(
     ${PROJECT_NAME}_test_dock_database_updater
-    test/unit/test_dock_database_updater.cpp src/dock_database_updater_node.cpp )
+    test/unit/test_dock_database_updater.cpp src/dock_database_updater_node.cpp)
   target_link_libraries(${PROJECT_NAME}_test_dock_database_updater yaml-cpp)
   target_include_directories(
     ${PROJECT_NAME}_test_dock_database_updater
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include>)
   ament_target_dependencies(${PROJECT_NAME}_test_dock_database_updater
-  ${PACKAGE_DEPENDENCIES})
+                            ${PACKAGE_DEPENDENCIES})
 
   ament_add_gtest(
     ${PROJECT_NAME}_test_send_to_dock_node test/unit/test_send_to_dock_node.cpp

--- a/husarion_ugv_docking/README.md
+++ b/husarion_ugv_docking/README.md
@@ -77,6 +77,7 @@ The package contains a `ChargingDock` plugin for the [opennav_docking](https://g
 - `<dock_name>.type` [*string*, default: **charging_dock**]: Type of the dock with the given name.
 - `<dock_name>.pose` [*list of doubles*, default: **[0.0, 0.0, 0.0]**]: Pose of the dock with the given name.
 - `<dock_name>.frame` [*string*, default: **main_wibotic_transmitter_link**]: Frame ID associated with the dock.
+
 ### SendToDockNode
 
 #### Service server

--- a/husarion_ugv_docking/README.md
+++ b/husarion_ugv_docking/README.md
@@ -15,6 +15,7 @@ The package contains a `ChargingDock` plugin for the [opennav_docking](https://g
 
 - `DockPosePublisherNode`: A lifecycle node listens to `tf` and republishes position of `dock_pose` in the fixed frame when it is activated.
 - `ChargingDock`:  A plugin for a Panther robot what is responsible for a charger service.
+- `DockDatabaseUpdater`: Listens to new poses for docking stations and reloads the database of `docking_server`.
 
 ### DockPosePublisherNode
 
@@ -56,6 +57,24 @@ The package contains a `ChargingDock` plugin for the [opennav_docking](https://g
 - `<dock_name>.apriltag_id` [*int*, default: **0**]: AprilTag ID of a dock.
 - `<dock_name>.dock_frame` [*string*, default: **main_wibotic_transmitter_link**]: A frame id to compare with fixed frame if docked.
 - `<dock_name>.pose` [*list*, default: **[0.0, 0.0, 0.0]**]: A pose of a dock on the map. If the simulation is used a dock is spawned in this pose.
+
+### DockDatabaseUpdater
+
+#### Subscribers
+
+- `<dock_name>/new_dock_pose` [*geometry_msgs/PoseStamped*]: A new pose for a dock with name `dock_name`.
+
+#### Service clients
+
+- `docking_server/reload_database` [*nav2_msgs/ReloadDockDatabase]: A service from `docking_server` to reload a database from yaml file.
+
+#### Parameters
+
+- `docks` [*list of strings*, default: **["main"]**]: List of dock names to be managed.
+- `dock_database_filepath` [*string*, default: **"dock_database.yaml"**]: Path to the new YAML file containing dock database information.
+- `<dock_name>.type` [*string*, default: **charging_dock**]: Type of the dock with the given name.
+- `<dock_name>.pose` [*list of doubles*, default: **[0.0, 0.0, 0.0]**]: Pose of the dock with the given name.
+- `<dock_name>.frame` [*string*, default: **main_wibotic_transmitter_link**]: Frame ID associated with the dock.
 
 <!-- Override description
 ros2 launch panther_description overwrite_robot_description.launch.py controller_config_path:=$(pwd)/panther_ros/panther_description/config/components.yaml namespace:=panther

--- a/husarion_ugv_docking/config/docking_server.yaml
+++ b/husarion_ugv_docking/config/docking_server.yaml
@@ -26,6 +26,7 @@
       use_wibotic_info: <use_wibotic_info_param>
       wibotic_info_timeout: 1.0
 
+    dock_database_filepath: dock_database.yaml
     docks: ["main", "backup"]
     main:
       type: charging_dock

--- a/husarion_ugv_docking/include/husarion_ugv_docking/dock_database_updater_node.hpp
+++ b/husarion_ugv_docking/include/husarion_ugv_docking/dock_database_updater_node.hpp
@@ -38,9 +38,12 @@ public:
       const std::string &node_name,
       const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
 
-private:
+protected:
   void PoseCallback(const std::string &dock_name, const std::string &dock_type,
                     const PoseStampedMsg::SharedPtr msg);
+
+  void ClearDatabaseFile();
+
   bool UpdateDatabaseFile(const std::string &dock_name,
                           const std::string &dock_type,
                           const PoseStampedMsg::SharedPtr pose);

--- a/husarion_ugv_docking/include/husarion_ugv_docking/dock_database_updater_node.hpp
+++ b/husarion_ugv_docking/include/husarion_ugv_docking/dock_database_updater_node.hpp
@@ -1,0 +1,59 @@
+// Copyright 2025 Husarion sp. z o.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HUSARION_UGV_DOCKING_HUSARION_UGV_DOCKING_POSE_CONVERTER_NODE_HPP_
+#define HUSARION_UGV_DOCKING_HUSARION_UGV_DOCKING_POSE_CONVERTER_NODE_HPP_
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include <yaml-cpp/yaml.h>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <nav2_msgs/srv/reload_dock_database.hpp>
+
+namespace husarion_ugv_docking
+{
+
+  using PoseStampedMsg = geometry_msgs::msg::PoseStamped;
+  using RealodDockDatabaseSrv = nav2_msgs::srv::ReloadDockDatabase;
+
+  class DockDatabaseUpdaterNode : public rclcpp::Node
+  {
+  public:
+    DockDatabaseUpdaterNode(
+        const std::string &node_name, const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
+
+  private:
+    void PoseCallback(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr msg);
+    bool UpdateDatabaseFile(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr pose);
+    YAML::Node UpdateDockDatabase(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr pose);
+    PoseStampedMsg::SharedPtr CreateInitialPose(
+        const std::string &frame, const std::vector<double> &pose_vec);
+    std::vector<rclcpp::Subscription<PoseStampedMsg>::SharedPtr> subscriptions_;
+    rclcpp::CallbackGroup::SharedPtr client_cb_group_;
+    rclcpp::Client<RealodDockDatabaseSrv>::SharedPtr reload_dock_database_client_;
+
+    YAML::Node yaml_file;
+    std::vector<std::string> dock_names_;
+    std::string filepath_;
+  };
+
+} // namespace husarion_ugv_docking
+
+#endif // HUSARION_UGV_DOCKING_HUSARION_UGV_DOCKING_POSE_CONVERTER_NODE_HPP_

--- a/husarion_ugv_docking/include/husarion_ugv_docking/dock_database_updater_node.hpp
+++ b/husarion_ugv_docking/include/husarion_ugv_docking/dock_database_updater_node.hpp
@@ -27,32 +27,37 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav2_msgs/srv/reload_dock_database.hpp>
 
-namespace husarion_ugv_docking
-{
+namespace husarion_ugv_docking {
 
-  using PoseStampedMsg = geometry_msgs::msg::PoseStamped;
-  using RealodDockDatabaseSrv = nav2_msgs::srv::ReloadDockDatabase;
+using PoseStampedMsg = geometry_msgs::msg::PoseStamped;
+using RealodDockDatabaseSrv = nav2_msgs::srv::ReloadDockDatabase;
 
-  class DockDatabaseUpdaterNode : public rclcpp::Node
-  {
-  public:
-    DockDatabaseUpdaterNode(
-        const std::string &node_name, const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
+class DockDatabaseUpdaterNode : public rclcpp::Node {
+public:
+  DockDatabaseUpdaterNode(
+      const std::string &node_name,
+      const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
 
-  private:
-    void PoseCallback(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr msg);
-    bool UpdateDatabaseFile(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr pose);
-    YAML::Node UpdateDockDatabase(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr pose);
-    PoseStampedMsg::SharedPtr CreateInitialPose(
-        const std::string &frame, const std::vector<double> &pose_vec);
-    std::vector<rclcpp::Subscription<PoseStampedMsg>::SharedPtr> subscriptions_;
-    rclcpp::CallbackGroup::SharedPtr client_cb_group_;
-    rclcpp::Client<RealodDockDatabaseSrv>::SharedPtr reload_dock_database_client_;
+private:
+  void PoseCallback(const std::string &dock_name, const std::string &dock_type,
+                    const PoseStampedMsg::SharedPtr msg);
+  bool UpdateDatabaseFile(const std::string &dock_name,
+                          const std::string &dock_type,
+                          const PoseStampedMsg::SharedPtr pose);
+  YAML::Node UpdateDockDatabase(const std::string &dock_name,
+                                const std::string &dock_type,
+                                const PoseStampedMsg::SharedPtr pose);
+  PoseStampedMsg::SharedPtr
+  CreateInitialPose(const std::string &frame,
+                    const std::vector<double> &pose_vec);
+  std::vector<rclcpp::Subscription<PoseStampedMsg>::SharedPtr> subscriptions_;
+  rclcpp::CallbackGroup::SharedPtr client_cb_group_;
+  rclcpp::Client<RealodDockDatabaseSrv>::SharedPtr reload_dock_database_client_;
 
-    YAML::Node yaml_file;
-    std::vector<std::string> dock_names_;
-    std::string filepath_;
-  };
+  YAML::Node yaml_file;
+  std::vector<std::string> dock_names_;
+  std::string filepath_;
+};
 
 } // namespace husarion_ugv_docking
 

--- a/husarion_ugv_docking/include/husarion_ugv_docking/dock_database_updater_node.hpp
+++ b/husarion_ugv_docking/include/husarion_ugv_docking/dock_database_updater_node.hpp
@@ -30,7 +30,7 @@
 namespace husarion_ugv_docking {
 
 using PoseStampedMsg = geometry_msgs::msg::PoseStamped;
-using RealodDockDatabaseSrv = nav2_msgs::srv::ReloadDockDatabase;
+using ReloadDockDatabaseSrv = nav2_msgs::srv::ReloadDockDatabase;
 
 class DockDatabaseUpdaterNode : public rclcpp::Node {
 public:
@@ -55,9 +55,9 @@ protected:
                     const std::vector<double> &pose_vec);
   std::vector<rclcpp::Subscription<PoseStampedMsg>::SharedPtr> subscriptions_;
   rclcpp::CallbackGroup::SharedPtr client_cb_group_;
-  rclcpp::Client<RealodDockDatabaseSrv>::SharedPtr reload_dock_database_client_;
+  rclcpp::Client<ReloadDockDatabaseSrv>::SharedPtr reload_dock_database_client_;
 
-  YAML::Node yaml_file;
+  YAML::Node yaml_file_;
   std::vector<std::string> dock_names_;
   std::string filepath_;
 };

--- a/husarion_ugv_docking/launch/docking.launch.py
+++ b/husarion_ugv_docking/launch/docking.launch.py
@@ -101,6 +101,7 @@ def generate_launch_description():
     docking_server_node = Node(
         package="opennav_docking",
         executable="opennav_docking",
+        name="docking_server",
         namespace=namespace,
         parameters=[
             namespaced_docking_server_config,
@@ -151,6 +152,19 @@ def generate_launch_description():
             "image_rect": camera_color_topic,
             "detections": "docking/april_tags",
         }.items(),
+    )
+
+    dock_database_updater = Node(
+        package="husarion_ugv_docking",
+        executable="dock_database_updater",
+        name="dock_database_updater",
+        namespace=namespace,
+        parameters=[
+            namespaced_docking_server_config,
+            {"use_sim_time": use_sim},
+        ],
+        emulate_tty=True,
+        arguments=["--ros-args", "--log-level", log_level, "--log-level", "rcl:=INFO"],
     )
 
     station_launch = IncludeLaunchDescription(
@@ -219,6 +233,7 @@ def generate_launch_description():
             docking_server_activate_node,
             dock_pose_publisher,
             apriltag_node,
+            dock_database_updater,
             docking_manager_node,
             wibotic_connector_can,
             spawn_charging_docks,

--- a/husarion_ugv_docking/launch/spawn_charging_docks.launch.py
+++ b/husarion_ugv_docking/launch/spawn_charging_docks.launch.py
@@ -47,6 +47,7 @@ def spawn_stations(context, *args, **kwargs):
         spawn_station = Node(
             package="ros_gz_sim",
             executable="create",
+            name=[dock_name, "_station_spawner"],
             arguments=[
                 "-name",
                 [dock_name, "_station"],

--- a/husarion_ugv_docking/package.xml
+++ b/husarion_ugv_docking/package.xml
@@ -35,7 +35,9 @@
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf2_ros</depend>
+  <depend>tf2</depend>
   <depend>wibotic_msgs</depend>
+  <depend>yaml-cpp</depend>
 
   <exec_depend>nav2_lifecycle_manager</exec_depend>
   <exec_depend>python3-imageio</exec_depend>

--- a/husarion_ugv_docking/package.xml
+++ b/husarion_ugv_docking/package.xml
@@ -34,8 +34,8 @@
   <depend>ros_gz_sim</depend>
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>tf2_ros</depend>
   <depend>tf2</depend>
+  <depend>tf2_ros</depend>
   <depend>wibotic_msgs</depend>
   <depend>yaml-cpp</depend>
 

--- a/husarion_ugv_docking/src/dock_database_updater_main.cpp
+++ b/husarion_ugv_docking/src/dock_database_updater_main.cpp
@@ -1,0 +1,42 @@
+// Copyright 2025 Husarion sp. z o.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "husarion_ugv_docking/dock_database_updater_node.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto dock_database_updater_node =
+    std::make_shared<husarion_ugv_docking::DockDatabaseUpdaterNode>("dock_database_updater_node");
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(dock_database_updater_node);
+
+  try {
+    executor.spin();
+  } catch (const std::runtime_error & e) {
+    std::cerr << "[dock_database_updater_node] Caught exception: " << e.what() << std::endl;
+  }
+
+  std::cout << "[dock_database_updater_node] Shutting down" << std::endl;
+  rclcpp::shutdown();
+  return 0;
+}

--- a/husarion_ugv_docking/src/dock_database_updater_main.cpp
+++ b/husarion_ugv_docking/src/dock_database_updater_main.cpp
@@ -20,20 +20,21 @@
 
 #include "husarion_ugv_docking/dock_database_updater_node.hpp"
 
-int main(int argc, char ** argv)
-{
+int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
 
   auto dock_database_updater_node =
-    std::make_shared<husarion_ugv_docking::DockDatabaseUpdaterNode>("dock_database_updater_node");
+      std::make_shared<husarion_ugv_docking::DockDatabaseUpdaterNode>(
+          "dock_database_updater_node");
 
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(dock_database_updater_node);
 
   try {
     executor.spin();
-  } catch (const std::runtime_error & e) {
-    std::cerr << "[dock_database_updater_node] Caught exception: " << e.what() << std::endl;
+  } catch (const std::runtime_error &e) {
+    std::cerr << "[dock_database_updater_node] Caught exception: " << e.what()
+              << std::endl;
   }
 
   std::cout << "[dock_database_updater_node] Shutting down" << std::endl;

--- a/husarion_ugv_docking/src/dock_database_updater_node.cpp
+++ b/husarion_ugv_docking/src/dock_database_updater_node.cpp
@@ -44,6 +44,8 @@ DockDatabaseUpdaterNode::DockDatabaseUpdaterNode(
   dock_names_ = this->get_parameter("docks").as_string_array();
   filepath_ = this->get_parameter("dock_database_filepath").as_string();
 
+  ClearDatabaseFile();
+
   for (const auto &dock_name : dock_names_) {
     std::string new_dock_pose_topic_name = dock_name + "/new_dock_pose";
 
@@ -141,6 +143,17 @@ YAML::Node DockDatabaseUpdaterNode::UpdateDockDatabase(
   yaml_dock["frame"] = pose->header.frame_id;
 
   return yaml_file;
+}
+
+void DockDatabaseUpdaterNode::ClearDatabaseFile() {
+  std::ofstream fout(filepath_, std::ofstream::out | std::ofstream::trunc);
+  if (!fout.is_open()) {
+    RCLCPP_ERROR(this->get_logger(),
+                 "Failed to open or create the dock database file: '%s'",
+                 filepath_.c_str());
+    throw std::runtime_error("Failed to open or create the dock database file");
+  }
+  fout.close();
 }
 
 bool DockDatabaseUpdaterNode::UpdateDatabaseFile(

--- a/husarion_ugv_docking/src/dock_database_updater_node.cpp
+++ b/husarion_ugv_docking/src/dock_database_updater_node.cpp
@@ -88,7 +88,7 @@ DockDatabaseUpdaterNode::DockDatabaseUpdaterNode(
 
   auto qos = rclcpp::QoS(rclcpp::ServicesQoS());
 
-  reload_dock_database_client_ = this->create_client<RealodDockDatabaseSrv>(
+  reload_dock_database_client_ = this->create_client<ReloadDockDatabaseSrv>(
       "docking_server/reload_database", qos, client_cb_group_);
 
   RCLCPP_INFO(this->get_logger(), "Node started.");
@@ -111,7 +111,7 @@ void DockDatabaseUpdaterNode::PoseCallback(
     return;
   }
 
-  auto request = std::make_shared<RealodDockDatabaseSrv::Request>();
+  auto request = std::make_shared<ReloadDockDatabaseSrv::Request>();
   request->filepath = filepath_;
 
   reload_dock_database_client_->async_send_request(request);
@@ -122,6 +122,7 @@ void DockDatabaseUpdaterNode::PoseCallback(
 YAML::Node DockDatabaseUpdaterNode::UpdateDockDatabase(
     const std::string &dock_name, const std::string &dock_type,
     const PoseStampedMsg::SharedPtr pose) {
+  YAML::Node yaml_file;
   auto yaml_docks = yaml_file["docks"];
   auto yaml_dock = yaml_docks[dock_name];
 
@@ -134,12 +135,6 @@ YAML::Node DockDatabaseUpdaterNode::UpdateDockDatabase(
   std::array<double, 3> pose_yaml = {pose->pose.position.x,
                                      pose->pose.position.y, yaw};
   yaml_dock["pose"] = pose_yaml;
-
-  std::string ns = this->get_namespace();
-  if (ns != "/") {
-    ns = ns.substr(1);
-  }
-
   yaml_dock["frame"] = pose->header.frame_id;
 
   return yaml_file;
@@ -160,10 +155,17 @@ bool DockDatabaseUpdaterNode::UpdateDatabaseFile(
     const std::string &dock_name, const std::string &dock_type,
     const PoseStampedMsg::SharedPtr pose) {
   try {
-    yaml_file = UpdateDockDatabase(dock_name, dock_type, pose);
+    yaml_file_ = UpdateDockDatabase(dock_name, dock_type, pose);
 
     std::ofstream fout(filepath_);
-    fout << yaml_file;
+    if (!fout.is_open()) {
+     RCLCPP_ERROR(this->get_logger(),
+                 "Failed to open or create the dock database file: '%s'",
+                 filepath_.c_str());
+      throw std::runtime_error("Failed to open or create the dock database file");
+    }
+
+    fout << yaml_file_;
     fout.close();
 
     RCLCPP_INFO(this->get_logger(), "Dock database file updated: '%s'",

--- a/husarion_ugv_docking/src/dock_database_updater_node.cpp
+++ b/husarion_ugv_docking/src/dock_database_updater_node.cpp
@@ -24,160 +24,162 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
-#include <rclcpp/rclcpp.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav2_msgs/srv/reload_dock_database.hpp>
 
-namespace husarion_ugv_docking
-{
+namespace husarion_ugv_docking {
 
-  DockDatabaseUpdaterNode::DockDatabaseUpdaterNode(
-      const std::string &node_name, const rclcpp::NodeOptions &options)
-      : Node(node_name, options)
-  {
-    this->declare_parameter<std::vector<std::string>>("docks", {"main"});
-    this->declare_parameter<std::string>("dock_database_filepath", "dock_database.yaml");
+DockDatabaseUpdaterNode::DockDatabaseUpdaterNode(
+    const std::string &node_name, const rclcpp::NodeOptions &options)
+    : Node(node_name, options) {
+  this->declare_parameter<std::vector<std::string>>("docks", {"main"});
+  this->declare_parameter<std::string>("dock_database_filepath",
+                                       "dock_database.yaml");
 
-    dock_names_ = this->get_parameter("docks").as_string_array();
-    filepath_ = this->get_parameter("dock_database_filepath").as_string();
+  dock_names_ = this->get_parameter("docks").as_string_array();
+  filepath_ = this->get_parameter("dock_database_filepath").as_string();
 
-    for (const auto &dock_name : dock_names_)
-    {
-      std::string new_dock_pose_topic_name = dock_name + "/new_dock_pose";
+  for (const auto &dock_name : dock_names_) {
+    std::string new_dock_pose_topic_name = dock_name + "/new_dock_pose";
 
-      this->declare_parameter<std::string>(dock_name + ".type", "charging_dock");
-      this->declare_parameter<std::vector<double>>(dock_name + ".pose", {0.0, 0.0, 0.0});
-      this->declare_parameter<std::string>(dock_name + ".frame", "map");
+    this->declare_parameter<std::string>(dock_name + ".type", "charging_dock");
+    this->declare_parameter<std::vector<double>>(dock_name + ".pose",
+                                                 {0.0, 0.0, 0.0});
+    this->declare_parameter<std::string>(dock_name + ".frame", "map");
 
-      std::string dock_type = this->get_parameter(dock_name + ".type").as_string();
-      std::vector<double> dock_pose = this->get_parameter(dock_name + ".pose").as_double_array();
-      std::string frame = this->get_parameter(dock_name + ".frame").as_string();
-      if (dock_pose.size() != 3)
-      {
-        RCLCPP_ERROR(this->get_logger(), "Invalid pose parameter for dock '%s'", dock_name.c_str());
-        throw std::runtime_error("Invalid pose parameter");
-      }
-
-      PoseStampedMsg::SharedPtr initial_pose = CreateInitialPose(frame, dock_pose);
-
-      if (!UpdateDatabaseFile(dock_name, dock_type, initial_pose))
-      {
-        RCLCPP_ERROR(this->get_logger(), "Failed to set initial pose in the dock database file.");
-        continue;
-      }
-
-      auto sub = this->create_subscription<PoseStampedMsg>(
-          new_dock_pose_topic_name, 10,
-          [this, dock_name, dock_type](const PoseStampedMsg::SharedPtr msg)
-          {
-            PoseCallback(dock_name, dock_type, msg);
-          });
-
-      subscriptions_.push_back(sub);
-      RCLCPP_INFO(this->get_logger(), "Subscribed to pose topic: '%s' for dock type '%s'", new_dock_pose_topic_name.c_str(), dock_type.c_str());
+    std::string dock_type =
+        this->get_parameter(dock_name + ".type").as_string();
+    std::vector<double> dock_pose =
+        this->get_parameter(dock_name + ".pose").as_double_array();
+    std::string frame = this->get_parameter(dock_name + ".frame").as_string();
+    if (dock_pose.size() != 3) {
+      RCLCPP_ERROR(this->get_logger(), "Invalid pose parameter for dock '%s'",
+                   dock_name.c_str());
+      throw std::runtime_error("Invalid pose parameter");
     }
 
-    auto qos = rclcpp::QoS(rclcpp::ServicesQoS());
+    PoseStampedMsg::SharedPtr initial_pose =
+        CreateInitialPose(frame, dock_pose);
 
-    reload_dock_database_client_ =
-        this->create_client<RealodDockDatabaseSrv>("docking_server/reload_database", qos, client_cb_group_);
+    if (!UpdateDatabaseFile(dock_name, dock_type, initial_pose)) {
+      RCLCPP_ERROR(this->get_logger(),
+                   "Failed to set initial pose in the dock database file.");
+      continue;
+    }
 
-    RCLCPP_INFO(this->get_logger(), "Node started.");
+    auto sub = this->create_subscription<PoseStampedMsg>(
+        new_dock_pose_topic_name, 10,
+        [this, dock_name, dock_type](const PoseStampedMsg::SharedPtr msg) {
+          PoseCallback(dock_name, dock_type, msg);
+        });
+
+    subscriptions_.push_back(sub);
+    RCLCPP_INFO(this->get_logger(),
+                "Subscribed to pose topic: '%s' for dock type '%s'",
+                new_dock_pose_topic_name.c_str(), dock_type.c_str());
   }
 
-  void DockDatabaseUpdaterNode::PoseCallback(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr msg)
-  {
-    RCLCPP_INFO(this->get_logger(), "Received pose.");
+  auto qos = rclcpp::QoS(rclcpp::ServicesQoS());
 
-    using namespace std::chrono_literals;
-    if (!reload_dock_database_client_->wait_for_service(1s))
-    {
-      RCLCPP_WARN(this->get_logger(), "Service not available, updating canceled.");
-      return;
-    }
+  reload_dock_database_client_ = this->create_client<RealodDockDatabaseSrv>(
+      "docking_server/reload_database", qos, client_cb_group_);
 
-    if (!UpdateDatabaseFile(dock_name, dock_type, msg))
-    {
-      RCLCPP_ERROR(this->get_logger(), "Failed to update dock database file.");
-      return;
-    }
+  RCLCPP_INFO(this->get_logger(), "Node started.");
+}
 
-    auto request = std::make_shared<RealodDockDatabaseSrv::Request>();
-    request->filepath = filepath_;
+void DockDatabaseUpdaterNode::PoseCallback(
+    const std::string &dock_name, const std::string &dock_type,
+    const PoseStampedMsg::SharedPtr msg) {
+  RCLCPP_INFO(this->get_logger(), "Received pose.");
 
-    reload_dock_database_client_->async_send_request(request);
-
-    RCLCPP_INFO(this->get_logger(), "Sent request to reload dock database.");
+  using namespace std::chrono_literals;
+  if (!reload_dock_database_client_->wait_for_service(1s)) {
+    RCLCPP_WARN(this->get_logger(),
+                "Service not available, updating canceled.");
+    return;
   }
 
-  YAML::Node DockDatabaseUpdaterNode::UpdateDockDatabase(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr pose)
-  {
-    auto yaml_docks = yaml_file["docks"];
-    auto yaml_dock = yaml_docks[dock_name];
-
-    yaml_dock["type"] = dock_type;
-
-    tf2::Quaternion q(
-        pose->pose.orientation.x, pose->pose.orientation.y, pose->pose.orientation.z,
-        pose->pose.orientation.w);
-
-    double yaw = tf2::getYaw(q);
-    std::array<double, 3> pose_yaml = {pose->pose.position.x, pose->pose.position.y, yaw};
-    yaml_dock["pose"] = pose_yaml;
-
-    std::string ns = this->get_namespace();
-    if (ns != "/")
-    {
-      ns = ns.substr(1);
-    }
-
-    yaml_dock["frame"] = pose->header.frame_id;
-
-    return yaml_file;
+  if (!UpdateDatabaseFile(dock_name, dock_type, msg)) {
+    RCLCPP_ERROR(this->get_logger(), "Failed to update dock database file.");
+    return;
   }
 
-  bool DockDatabaseUpdaterNode::UpdateDatabaseFile(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr pose)
-  {
-    try
-    {
-      yaml_file = UpdateDockDatabase(dock_name, dock_type, pose);
+  auto request = std::make_shared<RealodDockDatabaseSrv::Request>();
+  request->filepath = filepath_;
 
-      std::ofstream fout(filepath_);
-      fout << yaml_file;
-      fout.close();
+  reload_dock_database_client_->async_send_request(request);
 
-      RCLCPP_INFO(this->get_logger(), "Dock database file updated: '%s'", filepath_.c_str());
-      return true;
-    }
-    catch (const std::exception &e)
-    {
-      RCLCPP_ERROR(this->get_logger(), "Exception while updating dock database file: %s", e.what());
-      return false;
-    }
+  RCLCPP_INFO(this->get_logger(), "Sent request to reload dock database.");
+}
+
+YAML::Node DockDatabaseUpdaterNode::UpdateDockDatabase(
+    const std::string &dock_name, const std::string &dock_type,
+    const PoseStampedMsg::SharedPtr pose) {
+  auto yaml_docks = yaml_file["docks"];
+  auto yaml_dock = yaml_docks[dock_name];
+
+  yaml_dock["type"] = dock_type;
+
+  tf2::Quaternion q(pose->pose.orientation.x, pose->pose.orientation.y,
+                    pose->pose.orientation.z, pose->pose.orientation.w);
+
+  double yaw = tf2::getYaw(q);
+  std::array<double, 3> pose_yaml = {pose->pose.position.x,
+                                     pose->pose.position.y, yaw};
+  yaml_dock["pose"] = pose_yaml;
+
+  std::string ns = this->get_namespace();
+  if (ns != "/") {
+    ns = ns.substr(1);
   }
 
-  PoseStampedMsg::SharedPtr DockDatabaseUpdaterNode::CreateInitialPose(
-      const std::string &frame, const std::vector<double> &pose_vec)
-  {
-    auto pose_msg = std::make_shared<PoseStampedMsg>();
-    pose_msg->header.frame_id = frame;
-    pose_msg->header.stamp = this->now();
+  yaml_dock["frame"] = pose->header.frame_id;
 
-    pose_msg->pose.position.x = pose_vec[0];
-    pose_msg->pose.position.y = pose_vec[1];
-    pose_msg->pose.position.z = 0.0;
+  return yaml_file;
+}
 
-    tf2::Quaternion q;
-    q.setRPY(0, 0, pose_vec[2]);
-    pose_msg->pose.orientation.x = q.x();
-    pose_msg->pose.orientation.y = q.y();
-    pose_msg->pose.orientation.z = q.z();
-    pose_msg->pose.orientation.w = q.w();
+bool DockDatabaseUpdaterNode::UpdateDatabaseFile(
+    const std::string &dock_name, const std::string &dock_type,
+    const PoseStampedMsg::SharedPtr pose) {
+  try {
+    yaml_file = UpdateDockDatabase(dock_name, dock_type, pose);
 
-    return pose_msg;
+    std::ofstream fout(filepath_);
+    fout << yaml_file;
+    fout.close();
+
+    RCLCPP_INFO(this->get_logger(), "Dock database file updated: '%s'",
+                filepath_.c_str());
+    return true;
+  } catch (const std::exception &e) {
+    RCLCPP_ERROR(this->get_logger(),
+                 "Exception while updating dock database file: %s", e.what());
+    return false;
   }
+}
+
+PoseStampedMsg::SharedPtr DockDatabaseUpdaterNode::CreateInitialPose(
+    const std::string &frame, const std::vector<double> &pose_vec) {
+  auto pose_msg = std::make_shared<PoseStampedMsg>();
+  pose_msg->header.frame_id = frame;
+  pose_msg->header.stamp = this->now();
+
+  pose_msg->pose.position.x = pose_vec[0];
+  pose_msg->pose.position.y = pose_vec[1];
+  pose_msg->pose.position.z = 0.0;
+
+  tf2::Quaternion q;
+  q.setRPY(0, 0, pose_vec[2]);
+  pose_msg->pose.orientation.x = q.x();
+  pose_msg->pose.orientation.y = q.y();
+  pose_msg->pose.orientation.z = q.z();
+  pose_msg->pose.orientation.w = q.w();
+
+  return pose_msg;
+}
 } // namespace husarion_ugv_docking

--- a/husarion_ugv_docking/src/dock_database_updater_node.cpp
+++ b/husarion_ugv_docking/src/dock_database_updater_node.cpp
@@ -159,10 +159,11 @@ bool DockDatabaseUpdaterNode::UpdateDatabaseFile(
 
     std::ofstream fout(filepath_);
     if (!fout.is_open()) {
-     RCLCPP_ERROR(this->get_logger(),
-                 "Failed to open or create the dock database file: '%s'",
-                 filepath_.c_str());
-      throw std::runtime_error("Failed to open or create the dock database file");
+      RCLCPP_ERROR(this->get_logger(),
+                   "Failed to open or create the dock database file: '%s'",
+                   filepath_.c_str());
+      throw std::runtime_error(
+          "Failed to open or create the dock database file");
     }
 
     fout << yaml_file_;

--- a/husarion_ugv_docking/src/dock_database_updater_node.cpp
+++ b/husarion_ugv_docking/src/dock_database_updater_node.cpp
@@ -1,0 +1,183 @@
+// Copyright 2025 Husarion sp. z o.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "husarion_ugv_docking/dock_database_updater_node.hpp"
+
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <future>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <yaml-cpp/yaml.h>
+
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/utils.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <nav2_msgs/srv/reload_dock_database.hpp>
+
+namespace husarion_ugv_docking
+{
+
+  DockDatabaseUpdaterNode::DockDatabaseUpdaterNode(
+      const std::string &node_name, const rclcpp::NodeOptions &options)
+      : Node(node_name, options)
+  {
+    this->declare_parameter<std::vector<std::string>>("docks", {"main"});
+    this->declare_parameter<std::string>("dock_database_filepath", "dock_database.yaml");
+
+    dock_names_ = this->get_parameter("docks").as_string_array();
+    filepath_ = this->get_parameter("dock_database_filepath").as_string();
+
+    for (const auto &dock_name : dock_names_)
+    {
+      std::string new_dock_pose_topic_name = dock_name + "/new_dock_pose";
+
+      this->declare_parameter<std::string>(dock_name + ".type", "charging_dock");
+      this->declare_parameter<std::vector<double>>(dock_name + ".pose", {0.0, 0.0, 0.0});
+      this->declare_parameter<std::string>(dock_name + ".frame", "map");
+
+      std::string dock_type = this->get_parameter(dock_name + ".type").as_string();
+      std::vector<double> dock_pose = this->get_parameter(dock_name + ".pose").as_double_array();
+      std::string frame = this->get_parameter(dock_name + ".frame").as_string();
+      if (dock_pose.size() != 3)
+      {
+        RCLCPP_ERROR(this->get_logger(), "Invalid pose parameter for dock '%s'", dock_name.c_str());
+        throw std::runtime_error("Invalid pose parameter");
+      }
+
+      PoseStampedMsg::SharedPtr initial_pose = CreateInitialPose(frame, dock_pose);
+
+      if (!UpdateDatabaseFile(dock_name, dock_type, initial_pose))
+      {
+        RCLCPP_ERROR(this->get_logger(), "Failed to set initial pose in the dock database file.");
+        continue;
+      }
+
+      auto sub = this->create_subscription<PoseStampedMsg>(
+          new_dock_pose_topic_name, 10,
+          [this, dock_name, dock_type](const PoseStampedMsg::SharedPtr msg)
+          {
+            PoseCallback(dock_name, dock_type, msg);
+          });
+
+      subscriptions_.push_back(sub);
+      RCLCPP_INFO(this->get_logger(), "Subscribed to pose topic: '%s' for dock type '%s'", new_dock_pose_topic_name.c_str(), dock_type.c_str());
+    }
+
+    auto qos = rclcpp::QoS(rclcpp::ServicesQoS());
+
+    reload_dock_database_client_ =
+        this->create_client<RealodDockDatabaseSrv>("docking_server/reload_database", qos, client_cb_group_);
+
+    RCLCPP_INFO(this->get_logger(), "Node started.");
+  }
+
+  void DockDatabaseUpdaterNode::PoseCallback(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr msg)
+  {
+    RCLCPP_INFO(this->get_logger(), "Received pose.");
+
+    using namespace std::chrono_literals;
+    if (!reload_dock_database_client_->wait_for_service(1s))
+    {
+      RCLCPP_WARN(this->get_logger(), "Service not available, updating canceled.");
+      return;
+    }
+
+    if (!UpdateDatabaseFile(dock_name, dock_type, msg))
+    {
+      RCLCPP_ERROR(this->get_logger(), "Failed to update dock database file.");
+      return;
+    }
+
+    auto request = std::make_shared<RealodDockDatabaseSrv::Request>();
+    request->filepath = filepath_;
+
+    reload_dock_database_client_->async_send_request(request);
+
+    RCLCPP_INFO(this->get_logger(), "Sent request to reload dock database.");
+  }
+
+  YAML::Node DockDatabaseUpdaterNode::UpdateDockDatabase(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr pose)
+  {
+    auto yaml_docks = yaml_file["docks"];
+    auto yaml_dock = yaml_docks[dock_name];
+
+    yaml_dock["type"] = dock_type;
+
+    tf2::Quaternion q(
+        pose->pose.orientation.x, pose->pose.orientation.y, pose->pose.orientation.z,
+        pose->pose.orientation.w);
+
+    double yaw = tf2::getYaw(q);
+    std::array<double, 3> pose_yaml = {pose->pose.position.x, pose->pose.position.y, yaw};
+    yaml_dock["pose"] = pose_yaml;
+
+    std::string ns = this->get_namespace();
+    if (ns != "/")
+    {
+      ns = ns.substr(1);
+    }
+
+    yaml_dock["frame"] = pose->header.frame_id;
+
+    return yaml_file;
+  }
+
+  bool DockDatabaseUpdaterNode::UpdateDatabaseFile(const std::string &dock_name, const std::string &dock_type, const PoseStampedMsg::SharedPtr pose)
+  {
+    try
+    {
+      yaml_file = UpdateDockDatabase(dock_name, dock_type, pose);
+
+      std::ofstream fout(filepath_);
+      fout << yaml_file;
+      fout.close();
+
+      RCLCPP_INFO(this->get_logger(), "Dock database file updated: '%s'", filepath_.c_str());
+      return true;
+    }
+    catch (const std::exception &e)
+    {
+      RCLCPP_ERROR(this->get_logger(), "Exception while updating dock database file: %s", e.what());
+      return false;
+    }
+  }
+
+  PoseStampedMsg::SharedPtr DockDatabaseUpdaterNode::CreateInitialPose(
+      const std::string &frame, const std::vector<double> &pose_vec)
+  {
+    auto pose_msg = std::make_shared<PoseStampedMsg>();
+    pose_msg->header.frame_id = frame;
+    pose_msg->header.stamp = this->now();
+
+    pose_msg->pose.position.x = pose_vec[0];
+    pose_msg->pose.position.y = pose_vec[1];
+    pose_msg->pose.position.z = 0.0;
+
+    tf2::Quaternion q;
+    q.setRPY(0, 0, pose_vec[2]);
+    pose_msg->pose.orientation.x = q.x();
+    pose_msg->pose.orientation.y = q.y();
+    pose_msg->pose.orientation.z = q.z();
+    pose_msg->pose.orientation.w = q.w();
+
+    return pose_msg;
+  }
+} // namespace husarion_ugv_docking

--- a/husarion_ugv_docking/test/unit/test_dock_database_updater.cpp
+++ b/husarion_ugv_docking/test/unit/test_dock_database_updater.cpp
@@ -1,0 +1,168 @@
+// Copyright 2025 Husarion sp. z o.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <cmath>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/utils.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include "husarion_ugv_docking/dock_database_updater_node.hpp"
+
+static constexpr char kFilepath[] = "/tmp/dock_database.yaml";
+static constexpr char kDefaultFrame[] = "map";
+static constexpr char kDefaultDockName[] = "main";
+static constexpr char kDefaultDockType[] = "charging_dock";
+
+class DockDatabaseUpdaterWrapper
+    : public husarion_ugv_docking::DockDatabaseUpdaterNode {
+public:
+  DockDatabaseUpdaterWrapper(
+      const std::string &node_name,
+      const rclcpp::NodeOptions &options = rclcpp::NodeOptions())
+      : husarion_ugv_docking::DockDatabaseUpdaterNode(node_name, options) {}
+
+  void PoseCallback(const std::string &dock_name, const std::string &dock_type,
+                    const husarion_ugv_docking::PoseStampedMsg::SharedPtr msg) {
+    husarion_ugv_docking::DockDatabaseUpdaterNode::PoseCallback(dock_name,
+                                                                dock_type, msg);
+  }
+
+  bool UpdateDatabaseFile(
+      const std::string &dock_name, const std::string &dock_type,
+      const husarion_ugv_docking::PoseStampedMsg::SharedPtr pose) {
+    return husarion_ugv_docking::DockDatabaseUpdaterNode::UpdateDatabaseFile(
+        dock_name, dock_type, pose);
+  }
+
+  YAML::Node UpdateDockDatabase(
+      const std::string &dock_name, const std::string &dock_type,
+      const husarion_ugv_docking::PoseStampedMsg::SharedPtr pose) {
+    return husarion_ugv_docking::DockDatabaseUpdaterNode::UpdateDockDatabase(
+        dock_name, dock_type, pose);
+  }
+
+  husarion_ugv_docking::PoseStampedMsg::SharedPtr
+  CreateInitialPose(const std::string &frame,
+                    const std::vector<double> &pose_vec) {
+    return husarion_ugv_docking::DockDatabaseUpdaterNode::CreateInitialPose(
+        frame, pose_vec);
+  }
+};
+
+class TestDockDatabaseUpdater : public ::testing::Test {
+protected:
+  TestDockDatabaseUpdater();
+  void
+  CreateDockDatabaseUpdaterNode(const std::vector<rclcpp::Parameter> &params);
+
+  std::shared_ptr<DockDatabaseUpdaterWrapper> dock_database_updater_node_;
+};
+
+TestDockDatabaseUpdater::TestDockDatabaseUpdater() {
+  std::vector<rclcpp::Parameter> params;
+  params.emplace_back("dock_database_filepath", kFilepath);
+  CreateDockDatabaseUpdaterNode(params);
+}
+
+void TestDockDatabaseUpdater::CreateDockDatabaseUpdaterNode(
+    const std::vector<rclcpp::Parameter> &params) {
+  if (dock_database_updater_node_) {
+    dock_database_updater_node_.reset();
+  }
+
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(params);
+
+  dock_database_updater_node_ = std::make_shared<DockDatabaseUpdaterWrapper>(
+      "dock_database_updater_node_for_test", options);
+}
+
+TEST_F(TestDockDatabaseUpdater, CreateInitialPoseCreatesValidPose) {
+  std::vector<double> pose_vec = {1.0, 2.0, M_PI / 2};
+
+  auto pose =
+      dock_database_updater_node_->CreateInitialPose(kDefaultFrame, pose_vec);
+
+  EXPECT_EQ(pose->header.frame_id, kDefaultFrame);
+  EXPECT_DOUBLE_EQ(pose->pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(pose->pose.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(pose->pose.position.z, 0.0);
+
+  tf2::Quaternion q;
+  q.setRPY(0, 0, M_PI / 2);
+  EXPECT_DOUBLE_EQ(pose->pose.orientation.x, q.x());
+  EXPECT_DOUBLE_EQ(pose->pose.orientation.y, q.y());
+  EXPECT_DOUBLE_EQ(pose->pose.orientation.z, q.z());
+  EXPECT_DOUBLE_EQ(pose->pose.orientation.w, q.w());
+}
+
+TEST_F(TestDockDatabaseUpdater,
+       UpdateDockDatabaseCreatesValidYAMLWithDefaultParameters) {
+  YAML::Node yaml = YAML::LoadFile(kFilepath);
+
+  EXPECT_TRUE(yaml.IsMap());
+  ASSERT_EQ(yaml["docks"].size(), 1);
+  EXPECT_NO_THROW(yaml["docks"][kDefaultDockName]);
+  EXPECT_EQ(yaml["docks"][kDefaultDockName]["type"].as<std::string>(),
+            kDefaultDockType);
+  EXPECT_EQ(yaml["docks"][kDefaultDockName]["frame"].as<std::string>(),
+            kDefaultFrame);
+
+  auto pose_yaml = yaml["docks"][kDefaultDockName]["pose"];
+  ASSERT_TRUE(pose_yaml.IsSequence());
+  ASSERT_EQ(pose_yaml.size(), 3);
+  EXPECT_DOUBLE_EQ(pose_yaml[0].as<double>(), 0.0);
+  EXPECT_DOUBLE_EQ(pose_yaml[1].as<double>(), 0.0);
+  EXPECT_DOUBLE_EQ(pose_yaml[2].as<double>(), 0.0);
+}
+
+TEST_F(TestDockDatabaseUpdater, UpdateDatabaseFileHandlesExceptions) {
+  std::vector<rclcpp::Parameter> params;
+  params.emplace_back("dock_database_filepath",
+                      "/invalid_path/dock_database.yaml");
+  EXPECT_THROW(CreateDockDatabaseUpdaterNode(params), std::runtime_error);
+}
+
+TEST_F(TestDockDatabaseUpdater, UpdateDatabaseFileHandlesSavingFile) {
+  std::string dock_name = "dock1";
+  std::string dock_type = "typeA";
+  std::vector<double> pose_vec = {1.0, 2.0, M_PI / 2};
+
+  std::vector<rclcpp::Parameter> params;
+  params.emplace_back("docks", std::vector<std::string>({dock_name}));
+  params.emplace_back(dock_name + ".type", dock_type);
+  params.emplace_back(dock_name + ".pose", pose_vec);
+  params.emplace_back(dock_name + ".frame", kDefaultFrame);
+
+  auto pose =
+      dock_database_updater_node_->CreateInitialPose(kDefaultFrame, pose_vec);
+  bool result = dock_database_updater_node_->UpdateDatabaseFile(
+      dock_name, dock_type, pose);
+  EXPECT_TRUE(result);
+}
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+  return ret;
+}


### PR DESCRIPTION
The `DockDatabaseUpdaterNode` allows to change the poses of  docking stations. 

It subscribes the poses for every docking station, collects new poses and refreshes the docking_server databases.