### PR TITLE
Send robot to dock

### DIFF
--- a/husarion_ugv_docking/CMakeLists.txt
+++ b/husarion_ugv_docking/CMakeLists.txt
@@ -75,12 +75,12 @@ ament_target_dependencies(dock_pose_publisher ${PACKAGE_DEPENDENCIES})
 install(TARGETS dock_pose_publisher docking_manager_node
         DESTINATION lib/${PROJECT_NAME})
 
-add_executable(send_to_dock_node src/send_to_dock_node_main.cpp src/send_to_dock_node.cpp)
+add_executable(send_to_dock_node src/send_to_dock_node_main.cpp
+                                 src/send_to_dock_node.cpp)
 
 target_include_directories(
-  send_to_dock_node
-  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-         $<INSTALL_INTERFACE:include>)
+  send_to_dock_node PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
 
 ament_target_dependencies(send_to_dock_node ${PACKAGE_DEPENDENCIES})
 
@@ -137,13 +137,15 @@ if(BUILD_TESTING)
   ament_target_dependencies(${PROJECT_NAME}_test_tf2_utils
                             ${PACKAGE_DEPENDENCIES})
 
-  ament_add_gtest(${PROJECT_NAME}_test_send_to_dock_node
-                  test/unit/test_send_to_dock_node.cpp src/send_to_dock_node.cpp)
+  ament_add_gtest(
+    ${PROJECT_NAME}_test_send_to_dock_node test/unit/test_send_to_dock_node.cpp
+    src/send_to_dock_node.cpp)
   target_include_directories(
     ${PROJECT_NAME}_test_send_to_dock_node
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include>)
-  ament_target_dependencies(${PROJECT_NAME}_test_send_to_dock_node ${PACKAGE_DEPENDENCIES})
+  ament_target_dependencies(${PROJECT_NAME}_test_send_to_dock_node
+                            ${PACKAGE_DEPENDENCIES})
 endif()
 
 ament_export_include_directories(include)

--- a/husarion_ugv_docking/CMakeLists.txt
+++ b/husarion_ugv_docking/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PACKAGE_DEPENDENCIES
     opennav_docking_core
     pluginlib
     rclcpp
+    rclcpp_action
     rclcpp_lifecycle
     sensor_msgs
     std_srvs
@@ -74,6 +75,17 @@ ament_target_dependencies(dock_pose_publisher ${PACKAGE_DEPENDENCIES})
 install(TARGETS dock_pose_publisher docking_manager_node
         DESTINATION lib/${PROJECT_NAME})
 
+add_executable(send_to_dock_node src/send_to_dock_node_main.cpp src/send_to_dock_node.cpp)
+
+target_include_directories(
+  send_to_dock_node
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include>)
+
+ament_target_dependencies(send_to_dock_node ${PACKAGE_DEPENDENCIES})
+
+install(TARGETS send_to_dock_node DESTINATION lib/${PROJECT_NAME})
+
 add_library(dock_robot_bt_node SHARED src/plugins/action/dock_robot_node.cpp)
 list(APPEND plugin_libs dock_robot_bt_node)
 
@@ -124,6 +136,14 @@ if(BUILD_TESTING)
            $<INSTALL_INTERFACE:include>)
   ament_target_dependencies(${PROJECT_NAME}_test_tf2_utils
                             ${PACKAGE_DEPENDENCIES})
+
+  ament_add_gtest(${PROJECT_NAME}_test_send_to_dock_node
+                  test/unit/test_send_to_dock_node.cpp src/send_to_dock_node.cpp)
+  target_include_directories(
+    ${PROJECT_NAME}_test_send_to_dock_node
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+           $<INSTALL_INTERFACE:include>)
+  ament_target_dependencies(${PROJECT_NAME}_test_send_to_dock_node ${PACKAGE_DEPENDENCIES})
 endif()
 
 ament_export_include_directories(include)

--- a/husarion_ugv_docking/README.md
+++ b/husarion_ugv_docking/README.md
@@ -10,11 +10,13 @@ The package contains a `ChargingDock` plugin for the [opennav_docking](https://g
 ## Configuration Files
 
 - [`husarion_ugv_docking_server.yaml`](./config/docking_server.yaml): Defines parameters for a `docking_server` and a `ChargingDock` plugin. Defines poses where charging docks are spawned in the Gazebo.
+- `send_to_dock.yaml`: Defines parameters used by `send_to_dock_node` for docking action. 
 
 ## ROS Nodes
 
 - `DockPosePublisherNode`: A lifecycle node listens to `tf` and republishes position of `dock_pose` in the fixed frame when it is activated.
 - `ChargingDock`:  A plugin for a Panther robot what is responsible for a charger service.
+- `SendToDockNode`: A node which creates service server SetBool `send_robot_to_dock` and based on a request value sent (true/false) it either sends a robot to a dock or stops the docking action.
 
 ### DockPosePublisherNode
 
@@ -56,6 +58,25 @@ The package contains a `ChargingDock` plugin for the [opennav_docking](https://g
 - `<dock_name>.apriltag_id` [*int*, default: **0**]: AprilTag ID of a dock.
 - `<dock_name>.dock_frame` [*string*, default: **main_wibotic_transmitter_link**]: A frame id to compare with fixed frame if docked.
 - `<dock_name>.pose` [*list*, default: **[0.0, 0.0, 0.0]**]: A pose of a dock on the map. If the simulation is used a dock is spawned in this pose.
+
+
+### SendToDockNode
+
+#### Service server
+
+- `send_robot_to_dock` [*std_srvs/SetBool*]: Receives requests for docking or stopping the docking action.
+  - If *std_srvs/SetBool: true* then the node sends request of docking with specified parameters to the action client.
+  - If *std_srvs/SetBool: false* then the node sends request of cancelling current docking action.
+
+#### Action client
+
+- `dock_robot` [*nav2_msgs/DockRobot*]: Docks robot or stops docking depending on the request sent by the service server `send_robot_to_dock`.
+
+#### Parameters
+
+- `dock_type` [*string*, default: "charging_dock"]: Type of the dock the robot navigates to.
+- `navigate_to_staging_pose` [*bool*, default: true]: Whether the robot has to use navigation stack to dock or not.
+- `dock_id` [*string*, default: "main"]: Name of the docking station.
 
 <!-- Override description
 ros2 launch panther_description overwrite_robot_description.launch.py controller_config_path:=$(pwd)/panther_ros/panther_description/config/components.yaml namespace:=panther

--- a/husarion_ugv_docking/README.md
+++ b/husarion_ugv_docking/README.md
@@ -10,7 +10,7 @@ The package contains a `ChargingDock` plugin for the [opennav_docking](https://g
 ## Configuration Files
 
 - [`husarion_ugv_docking_server.yaml`](./config/docking_server.yaml): Defines parameters for a `docking_server` and a `ChargingDock` plugin. Defines poses where charging docks are spawned in the Gazebo.
-- `send_to_dock.yaml`: Defines parameters used by `send_to_dock_node` for docking action.
+- [`send_to_dock.yaml`](./config/send_to_dock.yaml): Defines parameters used by `send_to_dock_node` for docking action.
 
 ## ROS Nodes
 

--- a/husarion_ugv_docking/README.md
+++ b/husarion_ugv_docking/README.md
@@ -10,7 +10,7 @@ The package contains a `ChargingDock` plugin for the [opennav_docking](https://g
 ## Configuration Files
 
 - [`husarion_ugv_docking_server.yaml`](./config/docking_server.yaml): Defines parameters for a `docking_server` and a `ChargingDock` plugin. Defines poses where charging docks are spawned in the Gazebo.
-- `send_to_dock.yaml`: Defines parameters used by `send_to_dock_node` for docking action. 
+- `send_to_dock.yaml`: Defines parameters used by `send_to_dock_node` for docking action.
 
 ## ROS Nodes
 
@@ -58,7 +58,6 @@ The package contains a `ChargingDock` plugin for the [opennav_docking](https://g
 - `<dock_name>.apriltag_id` [*int*, default: **0**]: AprilTag ID of a dock.
 - `<dock_name>.dock_frame` [*string*, default: **main_wibotic_transmitter_link**]: A frame id to compare with fixed frame if docked.
 - `<dock_name>.pose` [*list*, default: **[0.0, 0.0, 0.0]**]: A pose of a dock on the map. If the simulation is used a dock is spawned in this pose.
-
 
 ### SendToDockNode
 

--- a/husarion_ugv_docking/config/send_to_dock.yaml
+++ b/husarion_ugv_docking/config/send_to_dock.yaml
@@ -1,0 +1,6 @@
+/**:
+  send_to_dock_node:
+    ros__parameters:
+      dock_type: charging_dock
+      navigate_to_staging_pose: true
+      dock_id: main

--- a/husarion_ugv_docking/include/husarion_ugv_docking/send_to_dock_node.hpp
+++ b/husarion_ugv_docking/include/husarion_ugv_docking/send_to_dock_node.hpp
@@ -1,0 +1,55 @@
+// Copyright 2025 Husarion sp. z o.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HUSARION_UGV_DOCKING_HUSARION_UGV_DOCKING_SEND_TO_DOCK_NODE_HPP_
+#define HUSARION_UGV_DOCKING_HUSARION_UGV_DOCKING_SEND_TO_DOCK_NODE_HPP_
+
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+
+#include <nav2_msgs/action/dock_robot.hpp>
+#include <std_srvs/srv/set_bool.hpp>
+
+namespace send_to_dock {
+using SetBoolSrv = std_srvs::srv::SetBool;
+using DockRobot = nav2_msgs::action::DockRobot;
+using GoalHandleDockRobot = rclcpp_action::ClientGoalHandle<DockRobot>;
+using SendGoalOptions = rclcpp_action::Client<DockRobot>::SendGoalOptions;
+
+class SendToDockNode : public rclcpp::Node {
+public:
+  SendToDockNode(const std::string &node_name = "send_to_dock_node",
+                 const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
+
+protected:
+  void HandleService(const SetBoolSrv::Request::SharedPtr request,
+                     SetBoolSrv::Response::SharedPtr response);
+  void FeedbackCallback(GoalHandleDockRobot::SharedPtr,
+                        const DockRobot::Feedback::ConstSharedPtr feedback);
+  void ResultCallback(const GoalHandleDockRobot::WrappedResult &result);
+  void GoalResponseCallback(GoalHandleDockRobot::SharedPtr goal_handle);
+  DockRobot::Goal CreateGoalMsg();
+  SendGoalOptions CreateGoalOptions();
+
+  GoalHandleDockRobot::SharedPtr active_goal_;
+  rclcpp_action::Client<DockRobot>::SharedPtr dock_action_client_;
+  rclcpp::Service<SetBoolSrv>::SharedPtr service_;
+  std::string dock_type_;
+  bool navigate_to_staging_pose_;
+  std::string dock_id_;
+};
+} // namespace send_to_dock
+#endif // HUSARION_UGV_DOCKING_HUSARION_UGV_DOCKING_SEND_TO_DOCK_NODE_HPP_

--- a/husarion_ugv_docking/include/husarion_ugv_docking/send_to_dock_node.hpp
+++ b/husarion_ugv_docking/include/husarion_ugv_docking/send_to_dock_node.hpp
@@ -31,8 +31,9 @@ using SendGoalOptions = rclcpp_action::Client<DockRobot>::SendGoalOptions;
 
 class SendToDockNode : public rclcpp::Node {
 public:
-  SendToDockNode(const std::string &node_name = "send_to_dock_node",
-                 const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
+  explicit SendToDockNode(
+      const std::string &node_name,
+      const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
 
 protected:
   void HandleService(const SetBoolSrv::Request::SharedPtr request,

--- a/husarion_ugv_docking/include/husarion_ugv_docking/send_to_dock_node.hpp
+++ b/husarion_ugv_docking/include/husarion_ugv_docking/send_to_dock_node.hpp
@@ -23,7 +23,7 @@
 #include <nav2_msgs/action/dock_robot.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 
-namespace send_to_dock {
+namespace husarion_ugv_docking {
 using SetBoolSrv = std_srvs::srv::SetBool;
 using DockRobot = nav2_msgs::action::DockRobot;
 using GoalHandleDockRobot = rclcpp_action::ClientGoalHandle<DockRobot>;
@@ -52,5 +52,5 @@ protected:
   bool navigate_to_staging_pose_;
   std::string dock_id_;
 };
-} // namespace send_to_dock
+} // namespace husarion_ugv_docking
 #endif // HUSARION_UGV_DOCKING_HUSARION_UGV_DOCKING_SEND_TO_DOCK_NODE_HPP_

--- a/husarion_ugv_docking/launch/docking.launch.py
+++ b/husarion_ugv_docking/launch/docking.launch.py
@@ -198,6 +198,15 @@ def generate_launch_description():
         emulate_tty=True,
     )
 
+    send_to_dock_node = Node(
+        package="husarion_ugv_docking",
+        executable="send_to_dock_node",
+        name="send_to_dock",
+        parameters=[send_to_dock_config_path],
+        namespace=namespace,
+        emulate_tty=True,
+    )
+
     spawn_charging_docks = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution(
@@ -212,15 +221,6 @@ def generate_launch_description():
             "namespace": namespace,
         }.items(),
         condition=IfCondition(use_sim),
-    )
-
-    send_to_dock_node = Node(
-        package="husarion_ugv_docking",
-        executable="send_to_dock_node",
-        name="send_to_dock",
-        parameters=[send_to_dock_config_path],
-        namespace=namespace,
-        emulate_tty=True,
     )
 
     return LaunchDescription(

--- a/husarion_ugv_docking/launch/docking.launch.py
+++ b/husarion_ugv_docking/launch/docking.launch.py
@@ -98,6 +98,15 @@ def generate_launch_description():
         },
     )
 
+    send_to_dock_config_path = LaunchConfiguration("send_to_dock_config_path")
+    declare_send_to_dock_config_path = DeclareLaunchArgument(
+        "send_to_dock_config_path",
+        default_value=PathJoinSubstitution(
+            [husarion_ugv_docking_dir, "config", "send_to_dock.yaml"]
+        ),
+        description="Specify path to configuration file for send robot to dock service",
+    )
+
     docking_server_node = Node(
         package="opennav_docking",
         executable="opennav_docking",
@@ -205,6 +214,15 @@ def generate_launch_description():
         condition=IfCondition(use_sim),
     )
 
+    send_to_dock_node = Node(
+        package="husarion_ugv_docking",
+        executable="send_to_dock_node",
+        name="send_to_dock",
+        parameters=[send_to_dock_config_path],
+        namespace=namespace,
+        emulate_tty=True,
+    )
+
     return LaunchDescription(
         [
             declare_apriltag_config_path_arg,
@@ -213,6 +231,7 @@ def generate_launch_description():
             declare_camera_info_topic_arg,
             declare_docking_server_config_path_arg,
             declare_log_level,
+            declare_send_to_dock_config_path,
             declare_use_wibotic_info_arg,
             station_launch,
             docking_server_node,
@@ -221,6 +240,7 @@ def generate_launch_description():
             apriltag_node,
             docking_manager_node,
             wibotic_connector_can,
+            send_to_dock_node,
             spawn_charging_docks,
         ]
     )

--- a/husarion_ugv_docking/package.xml
+++ b/husarion_ugv_docking/package.xml
@@ -30,6 +30,7 @@
   <depend>pluginlib</depend>
   <depend>python3-pip</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>ros_gz_sim</depend>
   <depend>sensor_msgs</depend>

--- a/husarion_ugv_docking/src/send_to_dock_node.cpp
+++ b/husarion_ugv_docking/src/send_to_dock_node.cpp
@@ -1,0 +1,146 @@
+// Copyright 2025 Husarion Sp. z o.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "husarion_ugv_docking/send_to_dock_node.hpp"
+
+namespace send_to_dock {
+
+SendToDockNode::SendToDockNode(const std::string &node_name,
+                               const rclcpp::NodeOptions &options)
+    : rclcpp::Node(node_name, options) {
+
+  this->declare_parameter("dock_type", "charging_dock");
+  this->declare_parameter("navigate_to_staging_pose", true);
+  this->declare_parameter("dock_id", "main");
+
+  this->get_parameter("dock_type", dock_type_);
+  this->get_parameter("navigate_to_staging_pose", navigate_to_staging_pose_);
+  this->get_parameter("dock_id", dock_id_);
+
+  dock_action_client_ =
+      rclcpp_action::create_client<DockRobot>(this, "dock_robot");
+
+  service_ = this->create_service<SetBoolSrv>(
+      "send_robot_to_dock",
+      std::bind(&SendToDockNode::HandleService, this, std::placeholders::_1,
+                std::placeholders::_2));
+
+  RCLCPP_INFO(this->get_logger(), "Service server 'send_robot_to_dock' ready");
+}
+
+void SendToDockNode::FeedbackCallback(
+    GoalHandleDockRobot::SharedPtr,
+    const DockRobot::Feedback::ConstSharedPtr feedback) {
+
+  RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
+                       "Feedback received: dock state = %d", feedback->state);
+}
+
+void SendToDockNode::ResultCallback(
+    const GoalHandleDockRobot::WrappedResult &result) {
+  switch (result.code) {
+  case rclcpp_action::ResultCode::SUCCEEDED:
+    RCLCPP_INFO(this->get_logger(), "Docking succeeded! Robot is charging.");
+    break;
+  case rclcpp_action::ResultCode::ABORTED:
+    RCLCPP_WARN(this->get_logger(), "Docking aborted!");
+    break;
+  case rclcpp_action::ResultCode::CANCELED:
+    RCLCPP_INFO(this->get_logger(), "Docking canceled by user.");
+    break;
+  default:
+    RCLCPP_ERROR(this->get_logger(), "Unknown result code.");
+    break;
+  }
+  active_goal_.reset();
+}
+
+void SendToDockNode::GoalResponseCallback(
+    GoalHandleDockRobot::SharedPtr goal_handle) {
+
+  if (!goal_handle) {
+    RCLCPP_ERROR(this->get_logger(), "Goal rejected by the server");
+    return;
+  }
+  RCLCPP_INFO(this->get_logger(), "Goal accepted by the server");
+  active_goal_ = goal_handle;
+}
+
+DockRobot::Goal SendToDockNode::CreateGoalMsg() {
+  auto goal_msg = DockRobot::Goal();
+  goal_msg.dock_type = dock_type_;
+  goal_msg.navigate_to_staging_pose = navigate_to_staging_pose_;
+  goal_msg.dock_id = dock_id_;
+
+  return goal_msg;
+}
+
+SendGoalOptions SendToDockNode::CreateGoalOptions() {
+  auto goal_options = rclcpp_action::Client<DockRobot>::SendGoalOptions();
+
+  goal_options.feedback_callback =
+      std::bind(&SendToDockNode::FeedbackCallback, this, std::placeholders::_1,
+                std::placeholders::_2);
+
+  goal_options.result_callback =
+      std::bind(&SendToDockNode::ResultCallback, this, std::placeholders::_1);
+
+  goal_options.goal_response_callback = std::bind(
+      &SendToDockNode::GoalResponseCallback, this, std::placeholders::_1);
+
+  return goal_options;
+}
+
+void SendToDockNode::HandleService(const SetBoolSrv::Request::SharedPtr request,
+                                   SetBoolSrv::Response::SharedPtr response) {
+
+  if (!this->dock_action_client_->wait_for_action_server(
+          std::chrono::seconds(2))) {
+    RCLCPP_ERROR(this->get_logger(),
+                 "Docking action server is not available after waiting");
+    response->success = false;
+    response->message = "Docking action server is not available";
+    return;
+  }
+
+  if (request->data) {
+    if (active_goal_) {
+      response->success = true; // Set to true after receiving every request for
+                                // proper functioning of Vizanti buttons
+      response->message = "Docking goal already exists.";
+      RCLCPP_WARN(this->get_logger(), "Docking goal already exists.");
+      return;
+    }
+
+    auto goal_msg = this->CreateGoalMsg();
+    auto goal_options = this->CreateGoalOptions();
+    dock_action_client_->async_send_goal(goal_msg, goal_options);
+    response->success = true;
+    response->message = "New docking goal request sent.";
+    RCLCPP_INFO(this->get_logger(), "New docking goal request sent.");
+    return;
+  }
+
+  if (active_goal_) {
+    dock_action_client_->async_cancel_all_goals();
+    response->success = true;
+    response->message = "Docking canceled.";
+    RCLCPP_INFO(this->get_logger(), "Docking canceled.");
+    return;
+  }
+  response->success = true;
+  response->message = "No active docking goal to cancel.";
+  RCLCPP_WARN(this->get_logger(), "No active docking goal to cancel.");
+}
+} // namespace send_to_dock

--- a/husarion_ugv_docking/src/send_to_dock_node.cpp
+++ b/husarion_ugv_docking/src/send_to_dock_node.cpp
@@ -14,7 +14,7 @@
 
 #include "husarion_ugv_docking/send_to_dock_node.hpp"
 
-namespace send_to_dock {
+namespace husarion_ugv_docking {
 
 SendToDockNode::SendToDockNode(const std::string &node_name,
                                const rclcpp::NodeOptions &options)
@@ -143,4 +143,4 @@ void SendToDockNode::HandleService(const SetBoolSrv::Request::SharedPtr request,
   response->message = "No active docking goal to cancel.";
   RCLCPP_WARN(this->get_logger(), "No active docking goal to cancel.");
 }
-} // namespace send_to_dock
+} // namespace husarion_ugv_docking

--- a/husarion_ugv_docking/src/send_to_dock_node_main.cpp
+++ b/husarion_ugv_docking/src/send_to_dock_node_main.cpp
@@ -1,0 +1,31 @@
+// Copyright 2025 Husarion sp. z o.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "husarion_ugv_docking/send_to_dock_node.hpp"
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+
+  auto send_to_dock_node = std::make_shared<send_to_dock::SendToDockNode>();
+
+  try {
+    rclcpp::spin(send_to_dock_node);
+  } catch (const std::runtime_error &err) {
+    std::cerr << "[send_to_dock] Caught exception: " << err.what() << std::endl;
+  }
+
+  std::cout << "[send_to_dock] Shutting down" << std::endl;
+  rclcpp::shutdown();
+  return 0;
+}

--- a/husarion_ugv_docking/src/send_to_dock_node_main.cpp
+++ b/husarion_ugv_docking/src/send_to_dock_node_main.cpp
@@ -17,7 +17,8 @@
 int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
 
-  auto send_to_dock_node = std::make_shared<send_to_dock::SendToDockNode>();
+  auto send_to_dock_node =
+      std::make_shared<send_to_dock::SendToDockNode>("send_to_dock_node");
 
   try {
     rclcpp::spin(send_to_dock_node);

--- a/husarion_ugv_docking/src/send_to_dock_node_main.cpp
+++ b/husarion_ugv_docking/src/send_to_dock_node_main.cpp
@@ -18,7 +18,8 @@ int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
 
   auto send_to_dock_node =
-      std::make_shared<send_to_dock::SendToDockNode>("send_to_dock_node");
+      std::make_shared<husarion_ugv_docking::SendToDockNode>(
+          "send_to_dock_node");
 
   try {
     rclcpp::spin(send_to_dock_node);

--- a/husarion_ugv_docking/test/unit/test_send_to_dock_node.cpp
+++ b/husarion_ugv_docking/test/unit/test_send_to_dock_node.cpp
@@ -1,0 +1,138 @@
+// Copyright 2025 Husarion Sp. z o.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+
+#include <nav2_msgs/action/dock_robot.hpp>
+
+#include "husarion_ugv_docking/send_to_dock_node.hpp"
+
+using DockRobot = nav2_msgs::action::DockRobot;
+using ClientGoalHandleDockRobot = rclcpp_action::ClientGoalHandle<DockRobot>;
+using ServerGoalHandleDockRobot = rclcpp_action::ServerGoalHandle<DockRobot>;
+using SetBoolSrv = std_srvs::srv::SetBool;
+
+class SendToDockNodeWrapper : public send_to_dock::SendToDockNode {
+public:
+  SendToDockNodeWrapper()
+      : send_to_dock::SendToDockNode("test_send_to_dock") {};
+
+  void HandleService(const SetBoolSrv::Request::SharedPtr request,
+                     SetBoolSrv::Response::SharedPtr response) {
+    return send_to_dock::SendToDockNode::HandleService(request, response);
+  }
+
+  ClientGoalHandleDockRobot::SharedPtr GetActiveGoal() {
+    return send_to_dock::SendToDockNode::active_goal_;
+  }
+
+  void SetActiveGoal() {
+    send_to_dock::SendToDockNode::active_goal_ =
+        ClientGoalHandleDockRobot::SharedPtr(
+            reinterpret_cast<ClientGoalHandleDockRobot *>(0x1), [](auto *) {});
+  }
+};
+
+class TestSendToDockNode : public testing::Test {
+protected:
+  TestSendToDockNode();
+  rclcpp_action::Server<DockRobot>::SharedPtr CreateDockServer();
+  std::shared_ptr<SendToDockNodeWrapper> node_;
+  SetBoolSrv::Request::SharedPtr request_;
+  SetBoolSrv::Response::SharedPtr response_;
+  rclcpp_action::Server<DockRobot>::SharedPtr action_server_;
+};
+
+TestSendToDockNode::TestSendToDockNode() {
+  node_ = std::make_shared<SendToDockNodeWrapper>();
+  request_ = std::make_shared<SetBoolSrv::Request>();
+  response_ = std::make_shared<SetBoolSrv::Response>();
+  action_server_ = nullptr;
+}
+
+rclcpp_action::Server<DockRobot>::SharedPtr
+TestSendToDockNode::CreateDockServer() {
+  return rclcpp_action::create_server<DockRobot>(
+      node_, "dock_robot",
+      // handle_goal
+      [](const rclcpp_action::GoalUUID &, DockRobot::Goal::ConstSharedPtr) {
+        return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+      },
+      // handle_cancel
+      [](const std::shared_ptr<ServerGoalHandleDockRobot>) {
+        return rclcpp_action::CancelResponse::ACCEPT;
+      },
+      // handle_accepted
+      [](const std::shared_ptr<ServerGoalHandleDockRobot> goal_handle) {
+        auto result = std::make_shared<DockRobot::Result>();
+        goal_handle->succeed(result);
+      });
+}
+
+TEST_F(TestSendToDockNode, DockRobotActionServerNotAvailable) {
+  node_->HandleService(request_, response_);
+  ASSERT_FALSE(response_->success);
+  EXPECT_EQ(response_->message, "Docking action server is not available");
+}
+
+TEST_F(TestSendToDockNode, DockServerSendDockGoal) {
+  action_server_ = CreateDockServer();
+  request_->data = true;
+  node_->HandleService(request_, response_);
+  ASSERT_TRUE(response_->success);
+  EXPECT_EQ(response_->message, "New docking goal request sent.");
+}
+
+TEST_F(TestSendToDockNode, DockServerNoGoalToCancel) {
+  action_server_ = CreateDockServer();
+  request_->data = false;
+  node_->HandleService(request_, response_);
+  ASSERT_TRUE(response_->success);
+  EXPECT_EQ(response_->message, "No active docking goal to cancel.");
+}
+
+TEST_F(TestSendToDockNode, DockServerGoalAlreadyActive) {
+  action_server_ = CreateDockServer();
+  node_->SetActiveGoal();
+  auto initial_active_goal = node_->GetActiveGoal();
+  request_->data = true;
+  node_->HandleService(request_, response_);
+  auto active_goal_after_request = node_->GetActiveGoal();
+  ASSERT_TRUE(response_->success);
+  EXPECT_EQ(response_->message, "Docking goal already exists.");
+  EXPECT_EQ(initial_active_goal, active_goal_after_request);
+}
+
+TEST_F(TestSendToDockNode, DockServerCancelDockGoal) {
+  action_server_ = CreateDockServer();
+  node_->SetActiveGoal();
+  request_->data = false;
+  node_->HandleService(request_, response_);
+  ASSERT_TRUE(response_->success);
+  EXPECT_EQ(response_->message, "Docking canceled.");
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(0, nullptr);
+
+  auto result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+  return result;
+}

--- a/husarion_ugv_docking/test/unit/test_send_to_dock_node.cpp
+++ b/husarion_ugv_docking/test/unit/test_send_to_dock_node.cpp
@@ -27,22 +27,23 @@ using ClientGoalHandleDockRobot = rclcpp_action::ClientGoalHandle<DockRobot>;
 using ServerGoalHandleDockRobot = rclcpp_action::ServerGoalHandle<DockRobot>;
 using SetBoolSrv = std_srvs::srv::SetBool;
 
-class SendToDockNodeWrapper : public send_to_dock::SendToDockNode {
+class SendToDockNodeWrapper : public husarion_ugv_docking::SendToDockNode {
 public:
   SendToDockNodeWrapper()
-      : send_to_dock::SendToDockNode("test_send_to_dock") {};
+      : husarion_ugv_docking::SendToDockNode("test_send_to_dock") {};
 
   void HandleService(const SetBoolSrv::Request::SharedPtr request,
                      SetBoolSrv::Response::SharedPtr response) {
-    return send_to_dock::SendToDockNode::HandleService(request, response);
+    return husarion_ugv_docking::SendToDockNode::HandleService(request,
+                                                               response);
   }
 
   ClientGoalHandleDockRobot::SharedPtr GetActiveGoal() {
-    return send_to_dock::SendToDockNode::active_goal_;
+    return husarion_ugv_docking::SendToDockNode::active_goal_;
   }
 
   void SetActiveGoal() {
-    send_to_dock::SendToDockNode::active_goal_ =
+    husarion_ugv_docking::SendToDockNode::active_goal_ =
         ClientGoalHandleDockRobot::SharedPtr(
             reinterpret_cast<ClientGoalHandleDockRobot *>(0x1), [](auto *) {});
   }


### PR DESCRIPTION
Add functionality of: sending a robot to a dock and cancelling such action.

Functionalities were tested. Unfortunately I could not run the whole simulation with my node added due to the following error: `gazebo | [spawner-8] [ERROR] [1760719833.054095666] [rmw_cyclonedds_cpp]: rmw_create_node: failed to create domain, error Error`.